### PR TITLE
Spectator fix bug

### DIFF
--- a/calypso.game.php
+++ b/calypso.game.php
@@ -33,6 +33,7 @@ class Calypso extends Table
         4 => '<span class="clp-suit-text-diamonds clp-suit-text">♦</span>',
     );
 
+    const DUMMY = 0;
     const SPADES = 1;
     const HEARTS = 2;
     const CLUBS = 3;
@@ -354,7 +355,8 @@ class Calypso extends Table
             self::CLUBS => self::DIAMONDS,
             self::DIAMONDS => self::CLUBS,
             self::HEARTS => self::SPADES,
-            self::SPADES => self::HEARTS
+            self::SPADES => self::HEARTS,
+            self::DUMMY => self::DUMMY,
         )[$player_suit];
     }
     // get suit the same colour as a given suit - feeds through to UI
@@ -363,20 +365,21 @@ class Calypso extends Table
             self::CLUBS => self::SPADES,
             self::DIAMONDS => self::HEARTS,
             self::HEARTS => self::DIAMONDS,
-            self::SPADES => self::CLUBS
+            self::SPADES => self::CLUBS,
+            self::DUMMY => self::DUMMY,
         )[$player_suit];
     }
 
     function getPlayerSuit($player_id) {
         $sql = "SELECT player_id, trump_suit FROM player WHERE player_id=".$player_id.";";
         $query_result = self::getCollectionFromDB( $sql, true );
-        return $query_result[$player_id];
+        return $query_result[$player_id] ?? 0;
     }
 
     function getPlayerIDFromSuit($suit){
         $sql = "SELECT trump_suit, player_id FROM player WHERE trump_suit=".$suit.";";
         $query_result = self::getCollectionFromDB( $sql, true );
-        return $query_result[$suit];
+        return $query_result[$suit] ?? 0;
     }
 
     function getPartnerID($player_id){

--- a/calypso.game.php
+++ b/calypso.game.php
@@ -33,7 +33,6 @@ class Calypso extends Table
         4 => '<span class="clp-suit-text-diamonds clp-suit-text">♦</span>',
     );
 
-    const DUMMY = 0;
     const SPADES = 1;
     const HEARTS = 2;
     const CLUBS = 3;
@@ -366,7 +365,6 @@ class Calypso extends Table
             self::DIAMONDS => self::CLUBS,
             self::HEARTS => self::SPADES,
             self::SPADES => self::HEARTS,
-            self::DUMMY => self::DUMMY,
         )[$player_suit];
     }
     // get suit the same colour as a given suit - feeds through to UI
@@ -376,7 +374,6 @@ class Calypso extends Table
             self::DIAMONDS => self::HEARTS,
             self::HEARTS => self::DIAMONDS,
             self::SPADES => self::CLUBS,
-            self::DUMMY => self::DUMMY,
         )[$player_suit];
     }
 

--- a/calypso.game.php
+++ b/calypso.game.php
@@ -273,16 +273,26 @@ class Calypso extends Table
         }
 
         $result['hand'] = $this->cards->getCardsInLocation( 'hand', $current_player_id );
-        $player_suit = self::getPlayerSuit($current_player_id);
-        $partner_suit = self::getPartnerSuit($player_suit);
-        // give suits in order: player suit, partner suit,
-        // same colour as player, same colour as partner
-        $result['suits_by_status'] = array(
-            +$player_suit,
-            $partner_suit,
-            self::getSameColourSuit($player_suit),
-            self::getSameColourSuit($partner_suit),
-        );
+        if (!self::isSpectator()){
+            $player_suit = self::getPlayerSuit($current_player_id);
+            $partner_suit = self::getPartnerSuit($player_suit);
+            // give suits in order: player suit, partner suit,
+            // same colour as player, same colour as partner
+            $result['suits_by_status'] = array(
+                +$player_suit,
+                $partner_suit,
+                self::getSameColourSuit($player_suit),
+                self::getSameColourSuit($partner_suit),
+            );
+        } else {
+            // dummy ranking to keep nice and smooth
+            $result['suits_by_status'] = array(
+                self::CLUBS,
+                self::DIAMONDS,
+                self::HEARTS,
+                self::SPADES,
+            );
+        }
 
         $result['cardsontable'] = $this->cards->getCardsInLocation( 'cardsontable' );
         $result['cardsincalypsos'] = $this->cards->getCardsInLocation( 'calypso' );
@@ -373,13 +383,13 @@ class Calypso extends Table
     function getPlayerSuit($player_id) {
         $sql = "SELECT player_id, trump_suit FROM player WHERE player_id=".$player_id.";";
         $query_result = self::getCollectionFromDB( $sql, true );
-        return $query_result[$player_id] ?? 0;
+        return $query_result[$player_id];
     }
 
     function getPlayerIDFromSuit($suit){
         $sql = "SELECT trump_suit, player_id FROM player WHERE trump_suit=".$suit.";";
         $query_result = self::getCollectionFromDB( $sql, true );
-        return $query_result[$suit] ?? 0;
+        return $query_result[$suit];
     }
 
     function getPartnerID($player_id){

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed spectator (silent) server errors by skipping problematic functions
+
 ## [beta-v01] - 2023-07-15
 
 Entered beta on 15/7 - no changes


### PR DESCRIPTION
There was a bug for spectators where the suit lookups would break (as spectators don't have a suit!). This only showed up directly in studio - in prod these happened quietly on server without being noticeable. Still nice to remove though, eh?
Just skip the nasty bit of logic if we are a spectator - we don't need it for the display then anyhow, as only relevant for player hands, which spectators don't have.